### PR TITLE
feat: add coverall yaml with proper hidden secret

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: ${{ secrets.COVERALL_TOKEN }}


### PR DESCRIPTION
It was missing the `.coverall.yaml` with the repo token. 
I didn't know how to add them in a secret way, but I think I managed how to do it:
- First add the token on `settings->secrets->repository secrets`
- Reference it on the YAML file with local env syntax